### PR TITLE
Wrap tweets neatly at 32 characters

### DIFF
--- a/twitter.py
+++ b/twitter.py
@@ -27,7 +27,7 @@
 # with dummy strings.
 
 from __future__ import print_function
-import base64, HTMLParser, httplib, json, sys, urllib, zlib
+import base64, HTMLParser, httplib, json, sys, urllib, zlib, textwrap
 from unidecode import unidecode
 from Adafruit_Thermal import *
 
@@ -113,9 +113,11 @@ for tweet in data['statuses']:
 
   # Remove HTML escape sequences
   # and remap Unicode values to nearest ASCII equivalents
-  printer.print(unidecode(
-    HTMLParser.HTMLParser().unescape(tweet['text'])))
-
+  # Use textwrap module to wrap neatly at 32 characters
+  tweettext=textwrap.wrap(unidecode(
+    HTMLParser.HTMLParser().unescape(tweet['text'])),32)
+  for line in tweettext:
+    printer.print(line + "\n")
   printer.feed(3)
 
 print(data['search_metadata']['max_id_str']) # Piped back to calling process


### PR DESCRIPTION
Using the existing code, tweets are hard-wrapped at 32 characters - which causes words to get cut off half-way through. This modification imports the textwrap module, and uses its wrap function to neatly wrap tweet text at 32 characters - making everything a lot more readable.
