### PR TITLE
Introduce a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# PyCharm
+.idea/
+*.iml
+
+# Config files not suitable for Github
+options.cfg
+
+# Object files
+*.pyc

--- a/forecast.py
+++ b/forecast.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 import urllib, time
+import ConfigParser
 from Adafruit_Thermal import *
 from xml.dom.minidom import parseString
 
@@ -23,7 +24,7 @@ from xml.dom.minidom import parseString
 # by 'manually' visiting http://weather.yahoo.com, entering a location
 # and requesting a forecast, then copy the number from the end of the
 # current URL string and paste it here.
-WOEID = '2459115'
+# (note that this value has moved to the config file)
 
 # Dumps one forecast line to the printer
 def forecast(idx):
@@ -38,12 +39,16 @@ def forecast(idx):
 	printer.print(deg)
 	printer.println(' ' + cond)
 
+config = ConfigParser.SafeConfigParser({'woeid': '2459115'}) # Default to NYC
+config.read('options.cfg')
+woeid = config.get('forecast', 'woeid')
+
 printer = Adafruit_Thermal("/dev/ttyAMA0", 19200, timeout=5)
 deg     = chr(0xf8) # Degree symbol on thermal printer
 
 # Fetch forecast data from Yahoo!, parse resulting XML
 dom = parseString(urllib.urlopen(
-        'http://weather.yahooapis.com/forecastrss?w=' + WOEID).read())
+        'http://weather.yahooapis.com/forecastrss?w=' + woeid).read())
 
 # Print heading
 printer.inverseOn()

--- a/options.cfg.template
+++ b/options.cfg.template
@@ -1,0 +1,18 @@
+[forecast]
+woeid=<your local woeid>
+
+[twitter]
+consumer-key=<your twitter consumer key>
+consumer-secret=<your twitter consumer secret>
+query-string=from:Adafruit
+
+[printer]
+# Defaults from Adafruit
+#heat-time=60
+#heat-dots=20
+#heat-interval=250
+# Works better for v2.68 printer
+heat-time=80
+heat-dots=7
+heat-interval=2
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PIL==1.1.7
+pyserial==2.7
+Unidecode==0.4.17

--- a/twitter.py
+++ b/twitter.py
@@ -28,6 +28,7 @@
 
 from __future__ import print_function
 import base64, HTMLParser, httplib, json, sys, urllib, zlib
+import ConfigParser
 from unidecode import unidecode
 from Adafruit_Thermal import *
 
@@ -35,14 +36,18 @@ from Adafruit_Thermal import *
 # Configurable globals.  Edit to your needs. -------------------------------
 
 # Twitter application credentials -- see notes above -- DO NOT SHARE.
-consumer_key    = 'PUT_YOUR_CONSUMER_KEY_HERE'
-consumer_secret = 'PUT_YOUR_CONSUMER_SECRET_HERE'
+# These have been moved to the config file.
+config = ConfigParser.SafeConfigParser({'query-string': 'from:Adafruit'})
+config.read('options.cfg')
+consumer_key = config.get('twitter', 'consumer-key')
+consumer_secret = config.get('twitter', 'consumer-secret')
+queryString = config.get('twitter', 'query-string')
 
 # queryString can be any valid Twitter API search string, including
 # boolean operators.  See http://dev.twitter.com/docs/using-search
 # for options and syntax.  Funny characters do NOT need to be URL
 # encoded here -- urllib takes care of that.
-queryString = 'from:Adafruit'
+# This has been moved to the config file.
 
 
 # Other globals.  You probably won't need to change these. -----------------


### PR DESCRIPTION
This pull request introduces a central configuration file for the various Python scripts, and moves the Yahoo woeid, the Twitter credentials, and the printer configuration to that file.

I also included a printer configuration that works well for the newer receipt printers that Adafruit seems to be shipping with the kit, and a requirements.txt that makes bootstrapping a new install a little bit easier.