### PR TITLE
Fix printImage crashing if given Image not path

### DIFF
--- a/Adafruit_Thermal.py
+++ b/Adafruit_Thermal.py
@@ -549,7 +549,11 @@ class Adafruit_Thermal(Serial):
 	# passing the result to this function.
 	def printImage(self, image_file, LaaT=False):
 		from PIL import Image
-		image = Image.open(image_file)
+		image = image_file
+
+		if isinstance(image_file, str):
+			image = Image.open(image_file)
+
 		if image.mode != '1':
 			image = image.convert('1')
 


### PR DESCRIPTION
Check that image_file parameter to printImage is a string before trying to open like a path. This resolves #38 