### PR TITLE
Removed class specific arguments from kwargs via "pop". Since this prevents "Serial" from initializing.

### DIFF
--- a/Adafruit_Thermal.py
+++ b/Adafruit_Thermal.py
@@ -72,7 +72,8 @@ class Adafruit_Thermal(Serial):
 		# with the 'firmware=X' argument, where X is the major
 		# version number * 100 + the minor version number (e.g.
 		# pass "firmware=264" for version 2.64.
-		self.firmwareVersion = kwargs.get('firmware', 268)
+		self.firmwareVersion = kwargs.pop('firmware', 268)
+		heatTime = kwargs.pop('heattime', self.defaultHeatTime)
 
 		if self.writeToStdout is False:
 			# Calculate time to issue one byte to the printer.
@@ -109,7 +110,6 @@ class Adafruit_Thermal(Serial):
 			# may occur.  The more heating interval, the more
 			# clear, but the slower printing speed.
 
-			heatTime = kwargs.get('heattime', self.defaultHeatTime)
 			self.writeBytes(
 			  27,       # Esc
 			  55,       # 7 (print settings)


### PR DESCRIPTION
If you pass firmware and/or heattime keyword arguments to Adafruit_Thermal it throws an exception since Serial class does not accept these arguments. So "pop" should be used instead of "get" in order to use these arguments.